### PR TITLE
Fix coverage

### DIFF
--- a/snapatac2-core/src/feature_count/data_iter.rs
+++ b/snapatac2-core/src/feature_count/data_iter.rs
@@ -40,7 +40,7 @@ fn single_to_fragments(
                 let row_end = row_offsets[i + 1];
                 (row_start..row_end)
                     .flat_map(|j| {
-                        let (chrom, start) = index.get_position(col_indices[j]);
+                        let (chrom, mut start) = index.get_position(col_indices[j]);
                         if exclude_chroms.contains(chrom) {
                             None
                         } else {

--- a/snapatac2-core/src/feature_count/data_iter.rs
+++ b/snapatac2-core/src/feature_count/data_iter.rs
@@ -54,6 +54,7 @@ fn single_to_fragments(
                                 strand = Some(Strand::Forward);
                             } else {
                                 end = start + 1;
+                                start = start - (size.abs() as u64);
                                 strand = Some(Strand::Reverse);
                             }
                             Some(Fragment {


### PR DESCRIPTION
- Negative strand export to bigwig only exported one base pair fragments.